### PR TITLE
add random num annotation to invalidate spec to allow adhoc restarts

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
       app: fe-template
   template:
     metadata:
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
       labels:
         app: fe-template
     spec:
@@ -80,6 +82,8 @@ spec:
       app: be-template
   template:
     metadata:
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
       labels:
         app: be-template
     spec:


### PR DESCRIPTION
FE and BE deployment specs can have this annotation:

```yaml
annotations:
    rollme: {{ randAlphaNum 5 | quote }}
```

This will invalidate the spec everytime it is applied on kube cluster. Which will inturn trigger a rollout of fresh pods.

As recommended here: https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments 